### PR TITLE
Adding the Chunk Method to the Query builder.

### DIFF
--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -229,7 +229,6 @@ class DynamoDbQueryBuilder
 
         if (!empty($this->lastEvaluatedKey)) {
             $query['ExclusiveStartKey'] = $this->lastEvaluatedKey;
-            $this->lastEvaluatedKey = [];
         }
 
         // If the $where is not empty, we run getIterator.
@@ -259,10 +258,7 @@ class DynamoDbQueryBuilder
                 $res = $this->client->query($query);
             }
 
-            if (!empty($res['LastEvaluatedKey'])) {
-                $this->lastEvaluatedKey = $res['LastEvaluatedKey'];
-            }
-
+            $this->lastEvaluatedKey = array_get($res, 'LastEvaluatedKey');
             $iterator = $res['Items'];
         }
 

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -24,6 +24,15 @@ class DynamoDbQueryBuilder
      */
     protected $client;
 
+    /**
+     * When not using the iterator, you can store the lastEvaluatedKey to
+     * paginate through the results. The getAll method will take this into account
+     * when used with $use_iterator = false.
+     *
+     * @var mixed
+     */
+    protected $lastEvaluatedKey;
+
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($boolean != 'and') {
@@ -85,6 +94,25 @@ class DynamoDbQueryBuilder
         ];
 
         return $this;
+    }
+
+    /**
+     * Implements the Query Chunk method
+     *
+     * @param int $chunk_size
+     * @param callable $callback
+     */
+    public function chunk($chunk_size, callable $callback)
+    {
+        while (true) {
+            $results = $this->getAll([], $chunk_size, false);
+
+            call_user_func($callback, $results);
+
+            if (empty($this->lastEvaluatedKey)) {
+                break;
+            }
+        }
     }
 
     public function find($id, array $columns = [])
@@ -177,7 +205,7 @@ class DynamoDbQueryBuilder
         return $this->getAll([$this->model->getKeyName()])->count();
     }
 
-    protected function getAll($columns = [], $limit = -1)
+    protected function getAll($columns = [], $limit = -1, $use_iterator = true)
     {
         if ($conditionValue = $this->conditionsContainKey()) {
             $item = $this->find($conditionValue, $columns);
@@ -192,11 +220,16 @@ class DynamoDbQueryBuilder
         $op = 'Scan';
 
         if ($limit > -1) {
-            $query['limit'] = $limit;
+            $query['Limit'] = $limit;
         }
 
         if (!empty($columns)) {
             $query['AttributesToGet'] = $columns;
+        }
+
+        if (!empty($this->lastEvaluatedKey)) {
+            $query['ExclusiveStartKey'] = $this->lastEvaluatedKey;
+            $this->lastEvaluatedKey = [];
         }
 
         // If the $where is not empty, we run getIterator.
@@ -217,7 +250,21 @@ class DynamoDbQueryBuilder
             $query['ScanFilter'] = $this->where;
         }
 
-        $iterator = $this->client->getIterator($op, $query);
+        if ($use_iterator) {
+            $iterator = $this->client->getIterator($op, $query);
+        } else {
+            if ($op == 'Scan') {
+                $res = $this->client->scan($query);
+            } else {
+                $res = $this->client->query($query);
+            }
+
+            if (!empty($res['LastEvaluatedKey'])) {
+                $this->lastEvaluatedKey = $res['LastEvaluatedKey'];
+            }
+
+            $iterator = $res['Items'];
+        }
 
         $results = [];
 

--- a/tests/DynamoDbModelTest.php
+++ b/tests/DynamoDbModelTest.php
@@ -330,12 +330,12 @@ class DynamoDbModelTest extends ModelTest
                 $this->assertEquals(2, count($results));
             } else if ($iteration == 2) {
                 $this->assertEquals(1, count($results));
-            } else {
-                $this->assertLessThan(3, $iteration);
             }
 
             $iteration++;
         });
+
+        $this->assertEquals(3, $iteration);
     }
 
     public function testChunkScanCondition()


### PR DESCRIPTION
@baopham - Couple of bits. Just adds an option to the getAll method to _not_ use the iterator (which as far as I can tell ignores the `Limit` param since it handles the chunking interally), and if not using the iterator it'll track the last pulled key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/baopham/laravel-dynamodb/22)
<!-- Reviewable:end -->
