### PR TITLE
drop paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "require": {
         "aws/aws-sdk-php": "^3.0.0",
         "illuminate/support": "~5.1",
-        "illuminate/database": "~5.1",
-        "paragonie/random_compat": "^1.1"
+        "illuminate/database": "~5.1"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This library in fact isn't used by `baopham/dynamodb` itself.

This fixes #27.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/baopham/laravel-dynamodb/29)
<!-- Reviewable:end -->
