### PR TITLE
Fix composite condition where conditions are not EQ

### DIFF
--- a/src/ComparisonOperator.php
+++ b/src/ComparisonOperator.php
@@ -7,20 +7,32 @@ namespace BaoPham\DynamoDb;
  */
 class ComparisonOperator
 {
+    const EQ = 'EQ';
+    const GT = 'GT';
+    const GE = 'GE';
+    const LT = 'LT';
+    const LE = 'LE';
+    const IN = 'IN';
+    const NE = 'NE';
+    const BEGINS_WITH = 'BEGINS_WITH';
+    const BETWEEN = 'BETWEEN';
+    const NOT_CONTAINS = 'NOT_CONTAINS';
+    const CONTAINS = 'CONTAINS';
+
     public static function getOperatorMapping()
     {
         return [
-            '=' => 'EQ',
-            '>' => 'GT',
-            '>=' => 'GE',
-            '<' => 'LT',
-            '<=' => 'LE',
-            'in' => 'IN',
-            '!=' => 'NE',
-            'begins_with' => 'BEGINS_WITH',
-            'between' => 'BETWEEN',
-            'not_contains' => 'NOT_CONTAINS',
-            'contains' => 'CONTAINS',
+            '=' => static::EQ,
+            '>' => static::GT,
+            '>=' => static::GE,
+            '<' => static::LT,
+            '<=' => static::LE,
+            'in' => static::IN,
+            '!=' => static::NE,
+            'begins_with' => static::BEGINS_WITH,
+            'between' => static::BETWEEN,
+            'not_contains' => static::NOT_CONTAINS,
+            'contains' => static::CONTAINS,
         ];
     }
 
@@ -51,17 +63,17 @@ class ComparisonOperator
     {
         if ($isRangeKey) {
             return [
-                'EQ',
-                'LE',
-                'LT',
-                'GE',
-                'GT',
-                'BEGINS_WITH',
-                'BETWEEN',
+                static::EQ,
+                static::LE,
+                static::LT,
+                static::GE,
+                static::GT,
+                static::BEGINS_WITH,
+                static::BETWEEN,
             ];
         }
 
-        return ['EQ'];
+        return [static::EQ];
     }
 
     public static function isValidQueryOperator($operator, $isRangeKey = false)

--- a/tests/DynamoDbCompositeModelTest.php
+++ b/tests/DynamoDbCompositeModelTest.php
@@ -123,7 +123,7 @@ class DynamoDbCompositeModelTest extends DynamoDbModelTest
         $this->assertArrayNotHasKey('Item', $record);
     }
 
-    public function testLookingUpByKey()
+    public function testLookUpByKey()
     {
         $this->seed();
 
@@ -137,6 +137,32 @@ class DynamoDbCompositeModelTest extends DynamoDbModelTest
         $this->assertEquals(1, $foundItems->count());
 
         $this->assertEquals($this->testModel->unmarshalItem($item), $foundItems->first()->toArray());
+    }
+
+    public function testSearchByHashAndSortKey()
+    {
+        $partitionKey = 'foo';
+        $item1 = $this->seed([
+            'id' => ['S' => $partitionKey],
+            'id2' => ['S' => 'bar_1']
+        ]);
+        $item2 = $this->seed([
+            'id' => ['S' => $partitionKey],
+            'id2' => ['S' => 'bar_2']
+        ]);
+        $this->seed([
+            'id' => ['S' => 'other'],
+            'id2' => ['S' => 'foo_1']
+        ]);
+
+        $foundItems = $this->testModel
+            ->where('id', $partitionKey)
+            ->where('id2', 'begins_with', 'bar')
+            ->get();
+
+        $this->assertEquals(2, $foundItems->count());
+        $this->assertEquals($this->testModel->unmarshalItem($item1), $foundItems->first()->toArray());
+        $this->assertEquals($this->testModel->unmarshalItem($item2), $foundItems->last()->toArray());
     }
 
     public function testStaticMethods()

--- a/tests/DynamoDbModelTest.php
+++ b/tests/DynamoDbModelTest.php
@@ -281,7 +281,7 @@ class DynamoDbModelTest extends ModelTest
         $this->assertEquals($this->testModel->unmarshalItem($secondItem), $foundItems->first()->toArray());
     }
 
-    public function testLookingUpByKey()
+    public function testLookUpByKey()
     {
         $this->seed();
 


### PR DESCRIPTION
Also, minor improvement by using Query instead of Scan if conditions contain the key. Currently, we only use Query if the conditions contain indexes.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/baopham/laravel-dynamodb/68)
<!-- Reviewable:end -->
