### PR TITLE
adds global query scope support

### DIFF
--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -68,12 +68,6 @@ abstract class DynamoDbModel extends Model
      */
     protected $dateFormat = DateTime::ATOM;
 
-    /**
-     * The array of global scopes on the model.
-     *
-     * @var array
-     */
-    protected static $globalScopes = [];
 
     public function __construct(array $attributes = [])
     {

--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -64,6 +64,12 @@ abstract class DynamoDbModel extends Model
      */
     protected $dateFormat = DateTime::ISO8601;
 
+    /**
+     * The array of global scopes on the model.
+     *
+     * @var array
+     */
+    protected static $globalScopes = [];
 
     public function __construct(array $attributes = [])
     {
@@ -204,6 +210,10 @@ abstract class DynamoDbModel extends Model
         $builder->setModel($this);
 
         $builder->setClient($this->client);
+
+        foreach ($this->getGlobalScopes() as $identifier => $scope) {
+            $builder->withGlobalScope($identifier, $scope);
+        }
 
         return $builder;
     }

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -524,27 +524,35 @@ class DynamoDbQueryBuilder
         if ($conditionValue = $this->conditionsContainKey()) {
             if ($this->conditionsAreExactSearch()) {
                 $item = $this->find($conditionValue, $columns);
+
                 return new Collection([$item]);
             }
         }
+
         $query = [
             'TableName' => $this->model->getTable(),
         ];
+
         if ($limit > -1) {
             $query['Limit'] = $limit;
         }
+
         if (!empty($columns)) {
             $query['ProjectionExpression'] = $this->projectionExpression->parse($columns);
         }
+
         if (!empty($this->lastEvaluatedKey)) {
             $query['ExclusiveStartKey'] = $this->lastEvaluatedKey;
         }
         $queryInfo = $this->buildExpressionQuery();
         $op = $queryInfo['op'];
         $query = array_merge($query, $queryInfo['query']);
+
         $this->cleanUpQuery($query);
+
         if ($use_iterator) {
             $iterator = $this->client->getIterator($op, $query);
+        
             if (isset($query['Limit'])) {
                 $iterator = new \LimitIterator($iterator, 0, $query['Limit']);
             }
@@ -554,10 +562,13 @@ class DynamoDbQueryBuilder
             } else {
                 $res = $this->client->query($query);
             }
+
             $this->lastEvaluatedKey = array_get($res, 'LastEvaluatedKey');
             $iterator = $res['Items'];
         }
+
         $results = [];
+
         foreach ($iterator as $item) {
             $item = $this->model->unmarshalItem($item);
             $model = $this->model->newInstance($item, true);
@@ -565,6 +576,7 @@ class DynamoDbQueryBuilder
             $model->syncOriginal();
             $results[] = $model;
         }
+        
         return new Collection($results);
     }
 

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -4,6 +4,7 @@ namespace BaoPham\DynamoDb;
 
 use Aws\DynamoDb\DynamoDbClient;
 use Exception;
+use Closure;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Log;
 
@@ -555,7 +556,7 @@ class DynamoDbQueryBuilder
             return $this;
         }
 
-        $builder = clone $this;
+        $builder = $this;
 
         foreach ($this->scopes as $identifier => $scope) {
             if (! isset($builder->scopes[$identifier])) {

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -41,16 +41,6 @@ class DynamoDbQueryBuilder
     protected $client;
 
     /**
-     * The methods that should be returned from query builder.
-     *
-     * @var array
-     */
-    protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql',
-        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection',
-    ];
-
-    /**
      * Applied global scopes.
      *
      * @var array
@@ -964,10 +954,6 @@ class DynamoDbQueryBuilder
     {
         if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
             return $this->callScope([$this->model, $scope], $parameters);
-        }
-
-        if (in_array($method, $this->passthru)) {
-            return $this->toBase()->{$method}(...$parameters);
         }
 
         $this->query->{$method}(...$parameters);

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -474,10 +474,10 @@ class DynamoDbQueryBuilder
 
     protected function getAll($columns = [], $limit = -1, $use_iterator = true)
     {
+        $this->applyScopes();
         if ($limit === -1 && isset($this->limit)) {
             $limit = $this->limit;
         }
-        $this->applyScopes();
         if ($conditionValue = $this->conditionsContainKey()) {
             if ($this->conditionsAreExactSearch()) {
                 $item = $this->find($conditionValue, $columns);
@@ -909,7 +909,6 @@ class DynamoDbQueryBuilder
      */
     public function __call($method, $parameters)
     {
-
         if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
             return $this->callScope([$this->model, $scope], $parameters);
         }

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -477,6 +477,7 @@ class DynamoDbQueryBuilder
         if ($limit === -1 && isset($this->limit)) {
             $limit = $this->limit;
         }
+        $this->applyScopes();
         if ($conditionValue = $this->conditionsContainKey()) {
             if ($this->conditionsAreExactSearch()) {
                 $item = $this->find($conditionValue, $columns);
@@ -897,5 +898,28 @@ class DynamoDbQueryBuilder
         // }
 
         return $result;
+    }
+
+    /**
+     * Dynamically handle calls into the query instance.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+
+        if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
+            return $this->callScope([$this->model, $scope], $parameters);
+        }
+
+        if (in_array($method, $this->passthru)) {
+            return $this->toBase()->{$method}(...$parameters);
+        }
+
+        $this->query->{$method}(...$parameters);
+
+        return $this;
     }
 }

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -26,11 +26,6 @@ class DynamoDbQueryBuilder
     protected $client;
 
     /**
-     * @var int
-     */
-    protected $limit = -1;
-
-    /**
      * The methods that should be returned from query builder.
      *
      * @var array
@@ -601,8 +596,6 @@ class DynamoDbQueryBuilder
         // // query as their own isolated nested where statement and avoid issues.
         // $originalWhereCount = is_null($query->wheres)
         //             ? 0 : count($query->wheres);
-
-        // var_dump($scope);
 
         $result = $scope(...array_values($parameters)) ?: $this;
 

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -518,6 +518,7 @@ class DynamoDbQueryBuilder
     protected function getAll($columns = [], $limit = -1, $use_iterator = true)
     {
         $this->applyScopes();
+
         if ($limit === -1 && isset($this->limit)) {
             $limit = $this->limit;
         }
@@ -544,6 +545,7 @@ class DynamoDbQueryBuilder
         if (!empty($this->lastEvaluatedKey)) {
             $query['ExclusiveStartKey'] = $this->lastEvaluatedKey;
         }
+
         $queryInfo = $this->buildExpressionQuery();
         $op = $queryInfo['op'];
         $query = array_merge($query, $queryInfo['query']);
@@ -552,7 +554,7 @@ class DynamoDbQueryBuilder
 
         if ($use_iterator) {
             $iterator = $this->client->getIterator($op, $query);
-        
+
             if (isset($query['Limit'])) {
                 $iterator = new \LimitIterator($iterator, 0, $query['Limit']);
             }
@@ -576,7 +578,7 @@ class DynamoDbQueryBuilder
             $model->syncOriginal();
             $results[] = $model;
         }
-        
+
         return new Collection($results);
     }
 

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -25,6 +25,35 @@ class DynamoDbQueryBuilder
     protected $client;
 
     /**
+     * @var int
+     */
+    protected $limit = -1;
+
+    /**
+     * The methods that should be returned from query builder.
+     *
+     * @var array
+     */
+    protected $passthru = [
+        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection',
+    ];
+
+    /**
+     * Applied global scopes.
+     *
+     * @var array
+     */
+    protected $scopes = [];
+
+    /**
+     * Removed global scopes.
+     *
+     * @var array
+     */
+    protected $removedScopes = [];
+
+    /**
      * When not using the iterator, you can store the lastEvaluatedKey to
      * paginate through the results. The getAll method will take this into account
      * when used with $use_iterator = false.
@@ -234,6 +263,8 @@ class DynamoDbQueryBuilder
         if (!empty($this->lastEvaluatedKey)) {
             $query['ExclusiveStartKey'] = $this->lastEvaluatedKey;
         }
+
+        $this->applyScopes();
 
         // If the $where is not empty, we run getIterator.
         if (!empty($this->where)) {
@@ -445,5 +476,139 @@ class DynamoDbQueryBuilder
     public function setClient($client)
     {
         $this->client = $client;
+    }
+
+    /**
+     * Register a new global scope.
+     *
+     * @param  string  $identifier
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+     * @return $this
+     */
+    public function withGlobalScope($identifier, $scope)
+    {
+        $this->scopes[$identifier] = $scope;
+
+        if (method_exists($scope, 'extend')) {
+            $scope->extend($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a registered global scope.
+     *
+     * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+     * @return $this
+     */
+    public function withoutGlobalScope($scope)
+    {
+        if (! is_string($scope)) {
+            $scope = get_class($scope);
+        }
+
+        unset($this->scopes[$scope]);
+
+        $this->removedScopes[] = $scope;
+
+        return $this;
+    }
+
+    /**
+     * Remove all or passed registered global scopes.
+     *
+     * @param  array|null  $scopes
+     * @return $this
+     */
+    public function withoutGlobalScopes(array $scopes = null)
+    {
+        if (is_array($scopes)) {
+            foreach ($scopes as $scope) {
+                $this->withoutGlobalScope($scope);
+            }
+        } else {
+            $this->scopes = [];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get an array of global scopes that were removed from the query.
+     *
+     * @return array
+     */
+    public function removedScopes()
+    {
+        return $this->removedScopes;
+    }
+
+    /**
+     * Apply the scopes to the Eloquent builder instance and return it.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function applyScopes()
+    {
+        if (! $this->scopes) {
+            return $this;
+        }
+
+        $builder = clone $this;
+
+        foreach ($this->scopes as $identifier => $scope) {
+            if (! isset($builder->scopes[$identifier])) {
+                continue;
+            }
+
+            $builder->callScope(function (DynamoDbQueryBuilder $builder) use ($scope) {
+                // If the scope is a Closure we will just go ahead and call the scope with the
+                // builder instance. The "callScope" method will properly group the clauses
+                // that are added to this query so "where" clauses maintain proper logic.
+                if ($scope instanceof Closure) {
+                    $scope($builder);
+                }
+
+                // If the scope is a scope object, we will call the apply method on this scope
+                // passing in the builder and the model instance. After we run all of these
+                // scopes we will return back the builder instance to the outside caller.
+                if ($scope instanceof Scope) {
+                    $scope->apply($builder, $this->getModel());
+                }
+            });
+        }
+
+        return $builder;
+    }
+
+    /**
+     * Apply the given scope on the current builder instance.
+     *
+     * @param  callable  $scope
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected function callScope(callable $scope, $parameters = [])
+    {
+        array_unshift($parameters, $this);
+
+        // $query = $this->getQuery();
+
+        // // We will keep track of how many wheres are on the query before running the
+        // // scope so that we can properly group the added scope constraints in the
+        // // query as their own isolated nested where statement and avoid issues.
+        // $originalWhereCount = is_null($query->wheres)
+        //             ? 0 : count($query->wheres);
+
+        // var_dump($scope);
+
+        $result = $scope(...array_values($parameters)) ?: $this;
+
+        // if (count((array) $query->wheres) > $originalWhereCount) {
+        //     $this->addNewWheresWithinGroup($query, $originalWhereCount);
+        // }
+
+        return $result;
     }
 }

--- a/tests/DynamoDbGlobalScopeTest.php
+++ b/tests/DynamoDbGlobalScopeTest.php
@@ -92,8 +92,7 @@ class GlobalScopeModel extends \BaoPham\DynamoDb\DynamoDbModel
     {
         parent::boot();
 
-        static::addGlobalScope('count', function (DynamoDbQueryBuilder $builder) 
-        {
+        static::addGlobalScope('count', function (DynamoDbQueryBuilder $builder) {
             $builder->where('count', '>', 6);
         });
     }

--- a/tests/DynamoDbGlobalScopeTest.php
+++ b/tests/DynamoDbGlobalScopeTest.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 use BaoPham\DynamoDb\DynamoDbQueryBuilder;
 
 /**
- * Class DynamoDbTimestampTest
+ * Class DynamoDbGlobalScopeTest
  *
  * @package BaoPham\DynamoDb\Tests
  */
@@ -21,7 +21,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     {
         $seeds = [];
         for ($x = 0; $x < 10; $x++) {
-            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+            $seeds[] = $this->seed(['count' => ['N' => $x]]);
         }
 
         $items = $this->testModel->all();
@@ -33,7 +33,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     {
         $seeds = [];
         for ($x = 0; $x < 10; $x++) {
-            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+            $seeds[] = $this->seed(['count' => ['N' => $x]]);
         }
 
         $items = $this->testModel->withoutGlobalScopes()->countUnderFour()->get();
@@ -45,7 +45,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     {
         $seeds = [];
         for ($x = 0; $x < 10; $x++) {
-            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+            $seeds[] = $this->seed(['count' => ['N' => $x]]);
         }
 
         $items = $this->testModel->withoutGlobalScopes()->countUnder(6)->get();

--- a/tests/DynamoDbGlobalScopeTest.php
+++ b/tests/DynamoDbGlobalScopeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace BaoPham\DynamoDb\Tests;
+
+use Carbon\Carbon;
+use BaoPham\DynamoDb\DynamoDbQueryBuilder;
+
+/**
+ * Class DynamoDbTimestampTest
+ *
+ * @package BaoPham\DynamoDb\Tests
+ */
+class DynamoDbGlobalScopeTest extends ModelTest
+{
+    protected function getTestModel()
+    {
+        return new GlobalScopeModel([]);
+    }
+
+    public function testGlobalScope()
+    {
+        $seeds = [];
+        for($x = 0; $x < 10; $x++) {
+            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+        }
+
+        $items = $this->testModel->all();
+
+        $this->assertEquals(3, count($items));
+    }
+
+    public function testLocalScope()
+    {
+        $seeds = [];
+        for($x = 0; $x < 10; $x++) {
+            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+        }
+
+        $items = $this->testModel->withoutGlobalScopes()->countUnderFour()->get();
+
+        $this->assertEquals(4, count($items));
+    }
+
+    public function testDynamicLocalScope()
+    {
+        $seeds = [];
+        for($x = 0; $x < 10; $x++) {
+            $seeds[] = $this->seed(['count'=>['N' => $x]]);
+        }
+
+        $items = $this->testModel->withoutGlobalScopes()->countUnder(6)->get();
+
+        $this->assertEquals(6, count($items));
+    }
+
+    protected function seed($attributes = [])
+    {
+        $item = [
+            'id' => ['S' => str_random(36)],
+            'name' => ['S' => str_random(36)],
+            'description' => ['S' => str_random(256)],
+            'count' => ['N' => rand()],
+            'author' => ['S' => str_random()],
+        ];
+
+        $item = array_merge($item, $attributes);
+
+        $this->dynamoDbClient->putItem([
+            'TableName' => $this->testModel->getTable(),
+            'Item' => $item,
+        ]);
+
+        return $item;
+    }
+}
+
+class GlobalScopeModel extends \BaoPham\DynamoDb\DynamoDbModel
+{
+    protected $fillable = ['name', 'description', 'count'];
+
+    protected $table = 'test_model';
+
+    public $timestamps = true;
+
+    protected $dynamoDbIndexKeys = [
+        'count_index' => [
+            'hash' => 'count',
+        ],
+    ];
+
+    protected static function boot() {
+        parent::boot();
+
+        static::addGlobalScope('count', function(DynamoDbQueryBuilder $builder) {
+            $builder->where('count', '>', 6);
+        });
+    }
+
+    public function scopeCountUnderFour($builder) {
+        return $builder->where('count', '<', 4);
+    }
+
+    public function scopeCountUnder($builder, $count) {
+        return $builder->where('count', '<', $count);
+    }
+}

--- a/tests/DynamoDbGlobalScopeTest.php
+++ b/tests/DynamoDbGlobalScopeTest.php
@@ -20,7 +20,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     public function testGlobalScope()
     {
         $seeds = [];
-        for($x = 0; $x < 10; $x++) {
+        for ($x = 0; $x < 10; $x++) {
             $seeds[] = $this->seed(['count'=>['N' => $x]]);
         }
 
@@ -32,7 +32,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     public function testLocalScope()
     {
         $seeds = [];
-        for($x = 0; $x < 10; $x++) {
+        for ($x = 0; $x < 10; $x++) {
             $seeds[] = $this->seed(['count'=>['N' => $x]]);
         }
 
@@ -44,7 +44,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     public function testDynamicLocalScope()
     {
         $seeds = [];
-        for($x = 0; $x < 10; $x++) {
+        for ($x = 0; $x < 10; $x++) {
             $seeds[] = $this->seed(['count'=>['N' => $x]]);
         }
 
@@ -88,19 +88,23 @@ class GlobalScopeModel extends \BaoPham\DynamoDb\DynamoDbModel
         ],
     ];
 
-    protected static function boot() {
+    protected static function boot()
+    {
         parent::boot();
 
-        static::addGlobalScope('count', function(DynamoDbQueryBuilder $builder) {
+        static::addGlobalScope('count', function (DynamoDbQueryBuilder $builder) 
+        {
             $builder->where('count', '>', 6);
         });
     }
 
-    public function scopeCountUnderFour($builder) {
+    public function scopeCountUnderFour($builder)
+    {
         return $builder->where('count', '<', 4);
     }
 
-    public function scopeCountUnder($builder, $count) {
+    public function scopeCountUnder($builder, $count)
+    {
         return $builder->where('count', '<', $count);
     }
 }

--- a/tests/DynamoDbQueryScopeTest.php
+++ b/tests/DynamoDbQueryScopeTest.php
@@ -6,15 +6,15 @@ use Carbon\Carbon;
 use BaoPham\DynamoDb\DynamoDbQueryBuilder;
 
 /**
- * Class DynamoDbGlobalScopeTest
+ * Class DynamoDbQueryScopeTest
  *
  * @package BaoPham\DynamoDb\Tests
  */
-class DynamoDbGlobalScopeTest extends ModelTest
+class DynamoDbQueryScopeTest extends ModelTest
 {
     protected function getTestModel()
     {
-        return new GlobalScopeModel([]);
+        return new ModelWithQueryScopes([]);
     }
 
     public function testGlobalScope()
@@ -74,7 +74,7 @@ class DynamoDbGlobalScopeTest extends ModelTest
     }
 }
 
-class GlobalScopeModel extends \BaoPham\DynamoDb\DynamoDbModel
+class ModelWithQueryScopes extends \BaoPham\DynamoDb\DynamoDbModel
 {
     protected $fillable = ['name', 'description', 'count'];
 


### PR DESCRIPTION
Example
```
class MyModel extends DynamoDbModel 
{
  public function boot() {
    parent::boot();
    static::addGlobalScope('type', function(DynamoDbQueryBuilder $builder) {
      return $builder->where('type', '=', 'value');
    });
  }
}
```

Everything is basically copied directly out of the Eloquent Builder class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/baopham/laravel-dynamodb/75)
<!-- Reviewable:end -->
