### PR TITLE
implemented "toRequestJson", similar to Eloquent's "toSql"

### DIFF
--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -540,10 +540,10 @@ class DynamoDbQueryBuilder
      * Similar to Eloquents `toSql()` call, but outputs the JSON passed to DynamoDb for the requests
      * @return string
      */ 
-    public function toRequestJson($columns = [], $limit = -1)
+    public function toRequestJson($columns = [], $limit = -1, $json_options = JSON_PRETTY_PRINT)
     {
         $queryInfo = $this->buildQueryInfo($columns, $limit);
-        return json_encode($queryInfo);
+        return json_encode($queryInfo, $json_options);
     }
 
     /**

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -556,7 +556,7 @@ class DynamoDbQueryBuilder
         if ($limit === -1 && isset($this->limit)) {
             $limit = $this->limit;
         }
-        
+
         if ($conditionValue = $this->conditionsContainKey()) {
             if ($this->conditionsAreExactSearch()) {
                 $item = $this->find($conditionValue, $columns);
@@ -599,7 +599,7 @@ class DynamoDbQueryBuilder
         $query = [];
 
         if (empty($this->wheres)) {
-            return compact('op', 'query');
+            return [ 'op' => $op, 'query' => $query ];
         }
 
         // Index key condition exists, then use Query instead of Scan.
@@ -659,7 +659,7 @@ class DynamoDbQueryBuilder
 
         $query['ExpressionAttributeValues'] = $this->expressionAttributeValues->all();
 
-        return compact('op', 'query');
+        return [ 'op' => $op, 'query' => $query ];
     }
 
     protected function conditionsAreExactSearch()

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -536,10 +536,11 @@ class DynamoDbQueryBuilder
 
         return new Collection($results);
     }
-    /** 
+
+    /**
      * Similar to Eloquents `toSql()` call, but outputs the JSON passed to DynamoDb for the requests
      * @return string
-     */ 
+     */
     public function toRequestJson($columns = [], $limit = -1, $json_options = JSON_PRETTY_PRINT)
     {
         $queryInfo = $this->buildQueryInfo($columns, $limit);


### PR DESCRIPTION
This would allow developers to log the Request's to DynamoDb in the same way they can log SQL using "toSql".  This also helps with debugging the Request's to DynamoDb.

Example
```
$query = Model::where('col', 'val')->where('col2', 'val2')->take(50);
Log::debug($query->toRequestJson());
$items = $query->get();
```

The `toRequestJson()` method returns an array that contains the `op` (Scan, Query), and the `query` (the body of the request sent to DynamoDB, including 'TableName', 'FilterExpression', etc).

I modified the `getAll()` method to make a call to `buildQueryInfo`, which moved the bulk majority of the logic in `getAll()` to `buildQueryInfo`.  `toRequestJson()` then makes the same call to `buildQueryInfo` as `getAll()` and just json_encode()'s the result so it can be logged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/baopham/laravel-dynamodb/81)
<!-- Reviewable:end -->
