### PR TITLE
skip/offset support

### DIFF
--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -253,6 +253,22 @@ abstract class DynamoDbModel extends Model
     }
 
     /**
+     * @return array
+     */
+    public function getCompositeKeyValue()
+    {
+        if(!$this->hasCompositeKey()) 
+            return new Exception(__CLASS__ . ' does not have a composite key');
+
+        $keys = $this->getCompositeKey();
+        $values = [];
+        foreach($keys as $k) {
+            $values[$k] = $this->{$k};
+        }
+        return $values;
+    }
+
+    /**
      * @param array $compositeKey
      */
     public function setCompositeKey($compositeKey)

--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -247,7 +247,7 @@ abstract class DynamoDbModel extends Model
     /**
      * @return array
      */
-    public function getCompositeKey()
+    public function getCompositeKeyName()
     {
         return $this->compositeKey;
     }
@@ -255,12 +255,12 @@ abstract class DynamoDbModel extends Model
     /**
      * @return array
      */
-    public function getCompositeKeyValue()
+    public function getCompositeKey()
     {
         if(!$this->hasCompositeKey()) 
             return new Exception(__CLASS__ . ' does not have a composite key');
 
-        $keys = $this->getCompositeKey();
+        $keys = $this->getCompositeKeyName();
         $values = [];
         foreach($keys as $k) {
             $values[$k] = $this->{$k};

--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -257,12 +257,13 @@ abstract class DynamoDbModel extends Model
      */
     public function getCompositeKey()
     {
-        if(!$this->hasCompositeKey()) 
+        if (!$this->hasCompositeKey()) {
             return new Exception(__CLASS__ . ' does not have a composite key');
+        }
 
         $keys = $this->getCompositeKeyName();
         $values = [];
-        foreach($keys as $k) {
+        foreach ($keys as $k) {
             $values[$k] = $this->{$k};
         }
         return $values;

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -115,8 +115,9 @@ class DynamoDbQueryBuilder
 
         if ($this->model->hasCompositeKey()) {
             // require $value to be an array
-            if (!is_array($value) && count($value) < 2) 
+            if (!is_array($value) && count($value) < 2) {
                 throw new InvalidArgumentException('$value must be an array with 2 elements when the model uses a Composite Key');
+            }
 
             $keys = $this->model->getCompositeKeyName();
             $last = [];

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -107,8 +107,18 @@ class DynamoDbQueryBuilder
      */
     public function setLastEvaluatedKey($value)
     {
-        $this->LastEvaluatedKey = $value;
+        if(empty($value)) {
+            $this->lastEvaluatedKey = null;
+        } else {
+            $this->lastEvaluatedKey = [ $this->model->getKeyName() => $this->model->getMarshaler()->marshalValue($value) ];
+        }
         return $this;
+    }
+
+    public function getLastEvaluatedKey()
+    {
+        // TODO: add support for composite keys
+        return empty($this->lastEvaluatedKey) ? null : $this->model->getMarshaler()->unmarshalValue(array_get($this->lastEvaluatedKey, $this->model->getKeyName(), null));
     }
 
     /**

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -78,6 +78,40 @@ class DynamoDbQueryBuilder
     }
 
     /**
+     * Alias to set the "offset" value of the query.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function skip($value)
+    {
+        return $this->offset($value);
+    }
+
+    /**
+     * Alias to set the "setLastEvaluatedKey" value of the query.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function offset($value)
+    {
+        return $this->setLastEvaluatedKey($value);
+    }
+
+    /**
+     * Set the "lastEvaluatedKey" value of the query.
+     *
+     * @param mixed $value
+     * @return $this
+     */
+    public function setLastEvaluatedKey($value)
+    {
+        $this->LastEvaluatedKey = $value;
+        return $this;
+    }
+
+    /**
      * Set the "limit" value of the query.
      *
      * @param  int  $value

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -108,14 +108,14 @@ class DynamoDbQueryBuilder
      */
     public function setLastEvaluatedKey($value)
     {
-        if(empty($value)) {
+        if (empty($value)) {
             $this->lastEvaluatedKey = null;
             return $this;
         }
 
-        if($this->model->hasCompositeKey()) {
+        if ($this->model->hasCompositeKey()) {
             // require $value to be an array
-            if(!is_array($value) && count($value) < 2) 
+            if (!is_array($value) && count($value) < 2) 
                 throw new InvalidArgumentException('$value must be an array with 2 elements when the model uses a Composite Key');
 
             $keys = $this->model->getCompositeKeyName();
@@ -126,7 +126,9 @@ class DynamoDbQueryBuilder
             return $this;
         }
 
-        if(is_array($value)) $value = array_shift($value);
+        if (is_array($value)) {
+            $value = array_shift($value);
+        }
         $this->lastEvaluatedKey = [ $this->model->getKeyName() => $this->model->getMarshaler()->marshalValue($value) ];
 
         return $this;
@@ -137,10 +139,10 @@ class DynamoDbQueryBuilder
         if (empty($this->lastEvaluatedKey))
             return null;
 
-        if($this->model->hasCompositeKey()) {
+        if ($this->model->hasCompositeKey()) {
             $keys = $this->model->getCompositeKeyName();
             $last = [];
-            foreach($keys as $k) {
+            foreach ($keys as $k) {
                 $last[$k] = $this->model->getMarshaler()->unmarshalValue(array_get($this->lastEvaluatedKey, $k));
             }
             return $last;

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -136,8 +136,9 @@ class DynamoDbQueryBuilder
 
     public function getLastEvaluatedKey()
     {
-        if (empty($this->lastEvaluatedKey))
+        if (empty($this->lastEvaluatedKey)) {
             return null;
+        }
 
         if ($this->model->hasCompositeKey()) {
             $keys = $this->model->getCompositeKeyName();

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -126,6 +126,7 @@ class DynamoDbQueryBuilder
             return $this;
         }
 
+        if(is_array($value)) $value = array_shift($value);
         $this->lastEvaluatedKey = [ $this->model->getKeyName() => $this->model->getMarshaler()->marshalValue($value) ];
 
         return $this;

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -118,7 +118,7 @@ class DynamoDbQueryBuilder
             if(!is_array($value) && count($value) < 2) 
                 throw new InvalidArgumentException('$value must be an array with 2 elements when the model uses a Composite Key');
 
-            $keys = $this->model->getCompositeKey();
+            $keys = $this->model->getCompositeKeyName();
             $last = [];
             $last[array_shift($keys)] = $this->model->getMarshaler()->marshalValue(array_shift($value));
             $last[array_shift($keys)] = $this->model->getMarshaler()->marshalValue(array_shift($value));
@@ -138,7 +138,7 @@ class DynamoDbQueryBuilder
             return null;
 
         if($this->model->hasCompositeKey()) {
-            $keys = $this->model->getCompositeKey();
+            $keys = $this->model->getCompositeKeyName();
             $last = [];
             foreach($keys as $k) {
                 $last[$k] = $this->model->getMarshaler()->unmarshalValue(array_get($this->lastEvaluatedKey, $k));
@@ -729,7 +729,7 @@ class DynamoDbQueryBuilder
 
         $model = $this->model;
 
-        $keys = $model->hasCompositeKey() ? $model->getCompositeKey() : [$model->getKeyName()];
+        $keys = $model->hasCompositeKey() ? $model->getCompositeKeyName() : [$model->getKeyName()];
 
         $conditionsContainKey = count(array_intersect($conditionKeys, $keys)) === count($keys);
 
@@ -784,7 +784,7 @@ class DynamoDbQueryBuilder
 
         $keys = [];
 
-        foreach ($this->model->getCompositeKey() as $key) {
+        foreach ($this->model->getCompositeKeyName() as $key) {
             $dynamoDbKey = $this->getSpecificDynamoDbKey($key, $this->model->getAttribute($key));
 
             if (!empty($dynamoDbKey)) {
@@ -826,7 +826,7 @@ class DynamoDbQueryBuilder
         }
 
         if ($hasCompositeKey) {
-            $compositeKey = $this->model->getCompositeKey();
+            $compositeKey = $this->model->getCompositeKeyName();
             if (isset($id[$compositeKey[0]]) && isset($id[$compositeKey[1]])) {
                 return false;
             }


### PR DESCRIPTION
* Refactored getCompositeKey and added getCompositeKeyName to match getKey/getKeyName from Eloquent
* Added skip/offset/setLastEvaluatedKey/getLastEvaluatedKey support
 - includes support for composite keys

Example usage:
```
Model::skip('primary-key')->chunk($pageSize, function($items) {
  // do something
});

Model::skip(['primary-key', 'sort-key'])->chunk($pageSize, function($items) {
  // do something
});
```

You can call `$item->getCompositeKey()` to return a keyed array containing the value of the primaryKey/sortKey.  This can then be passed to `skip`, `offset` or `setLastEvaluatedKey`.  Useful for processing large datasets and resuming after a failure.