### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["laravel", "dynamodb", "aws"],
     "require": {
         "aws/aws-sdk-php": "^3.0.0",
-        "illuminate/support": "~5.1",
-        "illuminate/database": "~5.1"
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.