### PR TITLE
Lumen support

### DIFF
--- a/src/DynamoDbServiceProvider.php
+++ b/src/DynamoDbServiceProvider.php
@@ -17,7 +17,7 @@ class DynamoDbServiceProvider extends ServiceProvider
         DynamoDbModel::setDynamoDbClientService($this->app->make(DynamoDbClientInterface::class));
 
         $this->publishes([
-            __DIR__.'/../config/dynamodb.php' => config_path('dynamodb.php'),
+            __DIR__.'/../config/dynamodb.php' => app()->path('dynamodb.php'),
         ]);
     }
 

--- a/src/DynamoDbServiceProvider.php
+++ b/src/DynamoDbServiceProvider.php
@@ -17,7 +17,7 @@ class DynamoDbServiceProvider extends ServiceProvider
         DynamoDbModel::setDynamoDbClientService($this->app->make(DynamoDbClientInterface::class));
 
         $this->publishes([
-            __DIR__.'/../config/dynamodb.php' => app()->path('dynamodb.php'),
+            __DIR__.'/../config/dynamodb.php' => app()->basePath('config/dynamodb.php'),
         ]);
     }
 


### PR DESCRIPTION
Fix `config_path` method not included in Lumen

`app()->basePath()` works both Laravel and Lumen :+1: 