### PR TITLE
updated DynamoDbQueryBuilder::chunk to follow Laravel's chunk

### DIFF
--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -428,13 +428,17 @@ class DynamoDbQueryBuilder
             $results = $this->getAll([], $chunkSize, false);
 
             if ($results->isNotEmpty()) {
-                call_user_func($callback, $results);
+                if(call_user_func($callback, $results) === false) {
+                    return false;
+                }
             }
 
             if (empty($this->lastEvaluatedKey)) {
                 break;
             }
         }
+
+        return true;
     }
 
     /**

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -428,7 +428,7 @@ class DynamoDbQueryBuilder
             $results = $this->getAll([], $chunkSize, false);
 
             if ($results->isNotEmpty()) {
-                if(call_user_func($callback, $results) === false) {
+                if (call_user_func($callback, $results) === false) {
                     return false;
                 }
             }


### PR DESCRIPTION
updated DynamoDbQueryBuilder::chunk to follow Laravel's `chunk` implementation.  Returning `false` from the callback will exit chunk early, allowing you to implement a type of "limit" process.

Reported in #174 