### PR TITLE
Improve analyzer

### DIFF
--- a/src/ConditionAnalyzer/Analyzer.php
+++ b/src/ConditionAnalyzer/Analyzer.php
@@ -171,12 +171,14 @@ class Analyzer
         }
 
         $index = null;
+        $keyIntersectionCount = 0;
 
         foreach ($this->model->getDynamoDbIndexKeys() as $name => $keysInfo) {
             $conditionKeys = array_pluck($this->conditions, 'column');
             $keys = array_values($keysInfo);
+            $keyIntersectionCount = count(array_intersect($conditionKeys, $keys));
 
-            if (count(array_intersect($conditionKeys, $keys)) === count($keys)) {
+            if ($keyIntersectionCount === 1 || $keyIntersectionCount === 2) {
                 if (!isset($this->indexName) || $this->indexName === $name) {
                     $index = new Index(
                         $name,
@@ -189,7 +191,7 @@ class Analyzer
             }
         }
 
-        if ($index && !$this->hasValidQueryOperator($index->hash, $index->range)) {
+        if ($index && !$this->hasValidQueryOperator($index->hash, $keyIntersectionCount === 2 ? $index->range : null)) {
             $index = null;
         }
 


### PR DESCRIPTION
The previous behavior allows the use of IndexKeys consisting of hash and range only if both are used. Dynamo also allows the use of only hash.

The changes allow this behavior. As a result, even when using only hash, a query is executed instead of scan.

Covers: https://github.com/baopham/laravel-dynamodb/issues/185