### PR TITLE
Updated to run with Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ stages:
   - test
 
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 
 before_script:
   - java -Djava.library.path=./DynamoDBLocal_lib -jar dynamodb_local/DynamoDBLocal.jar --port 3000 &

--- a/README.md
+++ b/README.md
@@ -608,3 +608,4 @@ Author and Contributors
 * [Alexander Ward](https://github.com/cthos)
 * [Quang Ngo](https://github.com/vanquang9387)
 * [David Higgins](https://github.com/zoul0813)
+* [Damon Williams](https://github.com/footballencarta)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Usage
 #### find() and delete()
 
 ```php
-$model->find(<id>);
+$model->find($id, array $columns = []);
+$model->findMany($ids, array $columns = []);
 $model->delete();
 $model->deleteAsync()->wait();
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Eloquent syntax for DynamoDB",
     "keywords": ["laravel", "dynamodb", "aws"],
     "require": {
-        "php": "^7.1.3",
         "aws/aws-sdk-php": "^3.0.0",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
         "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Eloquent syntax for DynamoDB",
     "keywords": ["laravel", "dynamodb", "aws"],
     "require": {
+        "php": "^7.1.3",
         "aws/aws-sdk-php": "^3.0.0",
         "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
         "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "keywords": ["laravel", "dynamodb", "aws"],
     "require": {
         "aws/aws-sdk-php": "^3.0.0",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
-        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*",
+        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
     },
     "license": "MIT",
     "authors": [
@@ -19,7 +19,6 @@
             "BaoPham\\DynamoDb\\": "src/"
         }
     },
-    "minimum-stability": "dev",
     "require-dev": {
         "orchestra/testbench": "~3.0"
     },

--- a/src/RawDynamoDbQuery.php
+++ b/src/RawDynamoDbQuery.php
@@ -136,6 +136,8 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * For backward compatibility, previously we use array to represent the raw query
      *
      * @var array
+     *
+     * @return array
      */
     private function internal()
     {

--- a/tests/DynamoDb/DynamoDbManagerTest.php
+++ b/tests/DynamoDb/DynamoDbManagerTest.php
@@ -20,7 +20,7 @@ class DynamoDbManagerTest extends DynamoDbTestCase
      */
     protected $mockedClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/DynamoDbClientServiceTest.php
+++ b/tests/DynamoDbClientServiceTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DynamoDbClientServiceTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -75,7 +75,7 @@ class DynamoDbClientServiceTest extends TestCase
     /**
      * Make sure we are not leaving any values set on the DynamoDbModel
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/DynamoDbModelTest.php
+++ b/tests/DynamoDbModelTest.php
@@ -21,7 +21,7 @@ abstract class DynamoDbModelTest extends DynamoDbTestCase
      */
     protected $marshaler;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/DynamoDbTestCase.php
+++ b/tests/DynamoDbTestCase.php
@@ -12,7 +12,7 @@ use Orchestra\Testbench\TestCase;
  */
 abstract class DynamoDbTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Parsers/ConditionExpressionTest.php
+++ b/tests/Parsers/ConditionExpressionTest.php
@@ -26,7 +26,7 @@ class ConditionExpressionTest extends TestCase
      */
     private $values;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->names = new ExpressionAttributeNames();

--- a/tests/Parsers/UpdateExpressionTest.php
+++ b/tests/Parsers/UpdateExpressionTest.php
@@ -18,7 +18,7 @@ class UpdateExpressionTest extends TestCase
      */
     private $names;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->names = new ExpressionAttributeNames();


### PR DESCRIPTION
Currently, the package does not work with Laravel 5.8 due to changes to the testcase which now requires a return type on the `setUp` and `tearDown` methods.

This change constitutes test fixes for this change, as well as dropping support for the versions of PHP in the travis file that will not support this change (5.6 and 7.0) and adding support for the latest version (7.3).

I've also incorporated the changes from #193 and #191 .

As the PHP version is now specified in the composer.json - this change should not affect users of now unsupported versions of PHP - however it may be worth releasing as a new major version to stop any accidental upgrades