### PR TITLE
Fix PHP ^7.4 Notice:  Trying to access array offset on value of type …

### DIFF
--- a/src/ConditionAnalyzer/Analyzer.php
+++ b/src/ConditionAnalyzer/Analyzer.php
@@ -201,7 +201,7 @@ class Analyzer
     {
         $hashCondition = $this->getCondition($hash);
 
-        $validQueryOp = ComparisonOperator::isValidQueryDynamoDbOperator($hashCondition['type']);
+        $validQueryOp = ComparisonOperator::isValidQueryDynamoDbOperator($hashCondition['type'] ?? null);
 
         if ($validQueryOp && $range) {
             $rangeCondition = $this->getCondition($range);


### PR DESCRIPTION
…null

It seems that under PHP ^7.4 this check is throwing an notice when trying to run a query without using primary/composite key as filter attributes (so when trying to run a DynamoDB scan). This fix checks if the key is set and uses null otherwise.