### PR TITLE
Allow connection name to be gathered dynamically

### DIFF
--- a/src/DynamoDbModel.php
+++ b/src/DynamoDbModel.php
@@ -352,7 +352,7 @@ abstract class DynamoDbModel extends Model
      */
     public function getClient()
     {
-        return static::$dynamoDb->getClient($this->connection);
+        return static::$dynamoDb->getClient($this->getConnectionName());
     }
 
     /**


### PR DESCRIPTION
Current functionality in the DynamoDbModel uses the property "connection" instead of calling the "getConnectionName()" method. This adds that functionality.