### PR TITLE
Validation for the find method

### DIFF
--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -451,7 +451,7 @@ class DynamoDbQueryBuilder
      */
     public function find($id, array $columns = [])
     {
-        if ($this->isMultipleIds($id)) {
+        if (is_array($id) && $this->isMultipleIds($id)) {
             return $this->findMany($id, $columns);
         }
 


### PR DESCRIPTION
$id is not always an array. Currently triggering "argument must be of type array|object" warning when using strings and integers. The validation fixes that issue.