### PR TITLE
add php 8.0 and 8.1 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
+  - '8.1'
 
 before_script:
   - java -Djava.library.path=./DynamoDBLocal_lib -jar dynamodb_local/DynamoDBLocal.jar --port 3000 &


### PR DESCRIPTION
Add 8.0 and 8.1 to the PHP versions to be tested in travis ci.

Laravel 9 only supports PHP version 8 or higher, so it is preferable to test for these versions.