### PR TITLE
pagedCount()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supports all key types - primary hash key and composite keys.
   * [save](#save) / [saveAsync()](#saveasync)
   * [delete](#delete) / [deleteAsync()](#deleteasync)
   * [chunk](#chunk)
+  * [pagedCount](#pagedcount)
   * [limit() and take()](#limit-and-take)
   * [firstOrFail()](#firstorfail)
   * [findOrFail()](#findorfail)
@@ -275,6 +276,17 @@ $model->chunk(10, function ($records) {
 
     }
 });
+```
+
+#### pagedCount()
+
+```php
+$countResult = $model->pagedCount();
+if($countResult->lastKey) {
+  $countResultNext = $model->setExclusiveStartKey($countResult->lastKey);
+  //...
+}
+
 ```
 
 #### limit() and take()

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -676,6 +676,22 @@ class DynamoDbQueryBuilder
 
         return $res['Count'];
     }
+    
+    public function pagedCount()
+    {
+        $limit = isset($this->limit) ? $this->limit : static::MAX_LIMIT;
+
+        $raw = $this->toDynamoDbQuery(['count(*)'], $limit);
+    
+        if ($raw->op === 'Scan') {
+            $res = $this->client->scan($raw->query);
+        } else {
+            $res = $this->client->query($raw->query);
+        }
+        $this->lastEvaluatedKey = Arr::get($res, 'LastEvaluatedKey');
+        
+        return (object)['count' => $res['Count'], 'scanned_count' => $res['ScannedCount'], 'lastKey' => $this->lastEvaluatedKey];
+    }
 
     public function decorate(Closure $closure)
     {


### PR DESCRIPTION
count() only counts correctly when scan or query is within 1MB dynamo limit

pagedCount() returns lastEvaluatedKey with count result on this page, if its != null then next count query should be executed