### PR TITLE
[fix] \IteratorAggregate, \ArrayAccess, \Countable compliance for PHP 8.1

### DIFF
--- a/src/RawDynamoDbQuery.php
+++ b/src/RawDynamoDbQuery.php
@@ -56,6 +56,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->internal()[$offset]);
@@ -70,6 +71,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->internal()[$offset];
@@ -87,6 +89,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->internal()[$offset] = $value;
@@ -101,6 +104,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->internal()[$offset]);
@@ -113,6 +117,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayObject($this->internal());
@@ -127,6 +132,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->internal());


### PR DESCRIPTION
Hi! On PHP 8.1, \BaoPham\DynamoDb\RawDynamoDbQuery class throws deprecation Notices.

This code 

```
$query = new \BaoPham\DynamoDb\RawDynamoDbQuery('', []);
$var = $query->offsetSet(1, 'test');
$res = $query->offsetGet(1);
```


Produces this amount of errors:
```
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>116</b><br />
<br />
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>59</b><br />
<br />
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>73</b><br />
<br />
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>90</b><br />
<br />
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>104</b><br />
<br />
<b>Deprecated</b>:  Return type of BaoPham\DynamoDb\RawDynamoDbQuery::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/app/vendor/baopham/dynamodb/src/RawDynamoDbQuery.php</b> on line <b>130</b><br />
```

All because of types mismatch concerning these internal PHP interfaces: \IteratorAggregate, \ArrayAccess, \Countable.
See https://wiki.php.net/rfc/internal_method_return_types for additional info.

I've made a fix for these issues. I tested it manually - it works.
I appreciate if You merge this PR if You are ok with these changes. Thanks!