### PR TITLE
feat: allow Laravel 10 and PHP 8.2 (basic)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
     "name": "baopham/dynamodb",
     "description": "Eloquent syntax for DynamoDB",
-    "keywords": ["laravel", "dynamodb", "aws"],
+    "keywords": [
+        "laravel",
+        "dynamodb",
+        "aws"
+    ],
     "require": {
         "aws/aws-sdk-php": "^3.0.0",
-        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0",
+        "illuminate/database": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0"
     },
     "license": "MIT",
     "authors": [
@@ -20,7 +24,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "~3.0 || ~5.0"
+        "orchestra/testbench": "~3.0 || ~5.0|^8.0"
     },
     "scripts": {
         "test": "phpunit",

--- a/src/RawDynamoDbQuery.php
+++ b/src/RawDynamoDbQuery.php
@@ -56,6 +56,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->internal()[$offset]);
@@ -70,6 +71,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return mixed Can return all value types.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->internal()[$offset];
@@ -87,6 +89,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->internal()[$offset] = $value;
@@ -101,6 +104,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * @return void
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->internal()[$offset]);
@@ -113,6 +117,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayObject($this->internal());
@@ -127,6 +132,7 @@ class RawDynamoDbQuery implements \IteratorAggregate, \ArrayAccess, \Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->internal());


### PR DESCRIPTION
Allow to install it in Laravel 10 / PHP 8.1+.

Replaces https://github.com/baopham/laravel-dynamodb/pull/266