### PR TITLE
feat(docker): add compatibility with dynamodb-local 2.0

### DIFF
--- a/config/dynamodb.php
+++ b/config/dynamodb.php
@@ -43,7 +43,7 @@ return [
         ],
         'local' => [
             'credentials' => [
-                'key' => 'dynamodb_local',
+                'key' => 'dynamodblocal',
                 'secret' => 'secret',
             ],
             'region' => 'stub',
@@ -53,7 +53,7 @@ return [
         ],
         'test' => [
             'credentials' => [
-                'key' => 'dynamodb_local',
+                'key' => 'dynamodblocal',
                 'secret' => 'secret',
             ],
             'region' => 'test',

--- a/tests/DynamoDbTestCase.php
+++ b/tests/DynamoDbTestCase.php
@@ -44,6 +44,6 @@ abstract class DynamoDbTestCase extends TestCase
 
     protected function setUpDatabase()
     {
-        copy(dirname(__FILE__) . '/../dynamodb_local_init.db', dirname(__FILE__) . '/../dynamodb_local_test.db');
+        copy(dirname(__FILE__) . '/../dynamodb_local_init.db', dirname(__FILE__) . '/../dynamodblocal_test.db');
     }
 }

--- a/tests/DynamoDbTestCase.php
+++ b/tests/DynamoDbTestCase.php
@@ -34,7 +34,7 @@ abstract class DynamoDbTestCase extends TestCase
     {
         $app['config']->set('dynamodb.connections.test', [
             'credentials' => [
-                'key' => 'dynamodb_local',
+                'key' => 'dynamodblocal',
                 'secret' => 'secret',
             ],
             'region' => 'test',


### PR DESCRIPTION
The recent 2.0.0 release of dynamodb_local no longer allows non-alphanumeric characters in the credential key as an incompatible change.
`config/dynamodb.php` use the string "dynamodb_local" as the key, but in dynamodb_local 2.0.0, using this string results in an error. This PR solves this problem.

https://hub.docker.com/r/amazon/dynamodb-local
> DynamoDB local version 2.0.0 and greater AWS_ACCESS_KEY_ID can contain the only letters (A–Z, a–z) and numbers (0–9). 