### PR TITLE
Fix failing tests and update phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          bootstrap="tests/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/tests/DynamoDb/DynamoDbManagerTest.php
+++ b/tests/DynamoDb/DynamoDbManagerTest.php
@@ -7,6 +7,7 @@ use Aws\DynamoDb\Marshaler;
 use BaoPham\DynamoDb\DynamoDbClientInterface;
 use BaoPham\DynamoDb\Tests\DynamoDbTestCase;
 use BaoPham\DynamoDb\DynamoDb\DynamoDbManager;
+use BaoPham\DynamoDb\Tests\Mocks\DynamoDbClientMock;
 
 class DynamoDbManagerTest extends DynamoDbTestCase
 {
@@ -25,9 +26,9 @@ class DynamoDbManagerTest extends DynamoDbTestCase
         parent::setUp();
 
         $this->mockedClient = $this
-            ->getMockBuilder(DynamoDbClient::class)
+            ->getMockBuilder(DynamoDbClientMock::class)
             ->disableOriginalConstructor()
-            ->setMethods(['putItem', 'updateItem', 'deleteItem', 'scan', 'query', 'batchWriteItem'])
+            ->onlyMethods(['putItem', 'updateItem', 'deleteItem', 'scan', 'query', 'batchWriteItem'])
             ->getMock();
 
         $service = $this->getMockBuilder(DynamoDbClientInterface::class)->getMock();

--- a/tests/Mocks/DynamoDbClientMock.php
+++ b/tests/Mocks/DynamoDbClientMock.php
@@ -7,27 +7,33 @@ use Aws\Result;
 
 class DynamoDbClientMock extends DynamoDbClient
 {
-    public function putItem(array $args = []): Result {
+    public function putItem(array $args = []): Result
+    {
         return parent::putItem($args);
     }
 
-    public function updateItem(array $args = []): Result {
+    public function updateItem(array $args = []): Result
+    {
         return parent::updateItem($args);
     }
 
-    public function deleteItem(array $args = []): Result {
+    public function deleteItem(array $args = []): Result
+    {
         return parent::deleteItem($args);
     }
 
-    public function scan(array $args = []): Result {
+    public function scan(array $args = []): Result
+    {
         return parent::scan($args);
     }
 
-    public function query(array $args = []): Result {
+    public function query(array $args = []): Result
+    {
         return parent::query($args);
     }
 
-    public function batchWriteItem(array $args = []): Result {
+    public function batchWriteItem(array $args = []): Result
+    {
         return parent::batchWriteItem($args);
     }
 }

--- a/tests/Mocks/DynamoDbClientMock.php
+++ b/tests/Mocks/DynamoDbClientMock.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BaoPham\DynamoDb\Tests\Mocks;
+
+use Aws\DynamoDb\DynamoDbClient;
+use Aws\Result;
+
+class DynamoDbClientMock extends DynamoDbClient
+{
+    public function putItem(array $args = []): Result {
+        return parent::putItem($args);
+    }
+
+    public function updateItem(array $args = []): Result {
+        return parent::updateItem($args);
+    }
+
+    public function deleteItem(array $args = []): Result {
+        return parent::deleteItem($args);
+    }
+
+    public function scan(array $args = []): Result {
+        return parent::scan($args);
+    }
+
+    public function query(array $args = []): Result {
+        return parent::query($args);
+    }
+
+    public function batchWriteItem(array $args = []): Result {
+        return parent::batchWriteItem($args);
+    }
+}


### PR DESCRIPTION
- Automatic update of `phpunit.xml`
- Replace `setMethods` (deprecated) with `onlyMethods` and add a new `DynamoDbClientMock` class to declare the needed methods (otherwise `onlyMethods` would not work) (see https://github.com/sebastianbergmann/phpunit/issues/4775)