### PR TITLE
Fix PHP 8.4 deprecation: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead

### DIFF
--- a/src/DynamoDb/QueryBuilder.php
+++ b/src/DynamoDb/QueryBuilder.php
@@ -97,7 +97,7 @@ class QueryBuilder
      * @param DynamoDbClient|null $client
      * @return ExecutableQuery
      */
-    public function prepare(DynamoDbClient $client = null)
+    public function prepare(?DynamoDbClient $client = null)
     {
         $raw = new RawDynamoDbQuery(null, $this->query);
         return new ExecutableQuery($client ?: $this->service->getClient(), $raw->finalize()->query);

--- a/src/DynamoDbCollection.php
+++ b/src/DynamoDbCollection.php
@@ -12,7 +12,7 @@ class DynamoDbCollection extends Collection
      */
     private $conditionIndex = null;
 
-    public function __construct(array $items = [], Index $conditionIndex = null)
+    public function __construct(array $items = [], ?Index $conditionIndex = null)
     {
         parent::__construct($items);
 

--- a/src/DynamoDbQueryBuilder.php
+++ b/src/DynamoDbQueryBuilder.php
@@ -147,7 +147,7 @@ class DynamoDbQueryBuilder
      *
      * @return $this
      */
-    public function after(DynamoDbModel $after = null)
+    public function after(?DynamoDbModel $after = null)
     {
         if (empty($after)) {
             $this->lastEvaluatedKey = null;
@@ -884,7 +884,7 @@ class DynamoDbQueryBuilder
      * @param  array|null  $scopes
      * @return $this
      */
-    public function withoutGlobalScopes(array $scopes = null)
+    public function withoutGlobalScopes(?array $scopes = null)
     {
         if (is_array($scopes)) {
             foreach ($scopes as $scope) {

--- a/src/H.php
+++ b/src/H.php
@@ -13,7 +13,7 @@ namespace BaoPham\DynamoDb;
 // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 class H
 {
-    public static function array_first($array, callable $callback = null, $default = null)
+    public static function array_first($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             if (empty($array)) {


### PR DESCRIPTION
```txt
BaoPham\DynamoDb\DynamoDbQueryBuilder::after(): Implicitly marking parameter $after as nullable is deprecated, the explicit nullable type must be used instead

BaoPham\DynamoDb\DynamoDbQueryBuilder::withoutGlobalScopes(): Implicitly marking parameter $scopes as nullable is deprecated, the explicit nullable type must be used instead

BaoPham\DynamoDb\DynamoDb\QueryBuilder::prepare(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead 

```